### PR TITLE
Add pytest marker for pep8

### DIFF
--- a/pytest_pep8.py
+++ b/pytest_pep8.py
@@ -21,6 +21,11 @@ def pytest_addoption(parser):
         help="max. line length (default: %d)" % pep8.MAX_LINE_LENGTH)
 
 
+def pytest_configure(config):
+    if config.option.pep8:
+        config.addinivalue_line('markers', 'pep8: Tests which run pep8.')
+
+
 def pytest_sessionstart(session):
     config = session.config
     if config.option.pep8:


### PR DESCRIPTION
This is required for compatibility with pytest --strict mode when using
pytest>=3.1 as discussed in pytest-dev/pytest#2455

Tested working on my machine.